### PR TITLE
Double ffmpeg process was being created when receiving multiple onDat…

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -215,6 +215,12 @@ let startPreparationTask = () => {
     let didShowQuestion = false
 
     /**
+     * Question status
+     * @type {Boolean}
+     */
+    let startedPrimaryTask = false
+
+    /**
      * Handles prepTask.stdout
      * @param {Buffer|String} data - FFmpeg Live Log Output Buffer
      */
@@ -230,7 +236,10 @@ let startPreparationTask = () => {
             }
             // Send SIGKILL: preparation task succeeded
             prepTask.kill('SIGKILL')
-            startPrimaryTask(outputDuration, outputFilename)
+            if (!startedPrimaryTask) {
+                startedPrimaryTask = true
+                startPrimaryTask(outputDuration, outputFilename)
+            }
         }
     }
 


### PR DESCRIPTION
Running in Windows I got 2 main task processes started as multiple onData calls were executed. This change makes sure that the main task only gets started once.