### PR TITLE
update main.js to only launch main worker process once

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -212,9 +212,15 @@ let startPreparationTask = () => {
      * Question status
      * @type {Boolean}
      */
-    let didShowQuestion = false
+     let didShowQuestion = false
 
     /**
+     * Primary Task Started
+     * @type {Boolean}
+     */
+     let didStartPrimaryTask = false
+
+     /**
      * Handles prepTask.stdout
      * @param {Buffer|String} data - FFmpeg Live Log Output Buffer
      */
@@ -230,7 +236,10 @@ let startPreparationTask = () => {
             }
             // Send SIGKILL: preparation task succeeded
             prepTask.kill('SIGKILL')
-            startPrimaryTask(outputDuration, outputFilename)
+            if(!didStartPrimaryTask) {
+                startPrimaryTask(outputDuration, outputFilename)
+                didStartPrimaryTask = true
+            }
         }
     }
 


### PR DESCRIPTION
This is to address https://github.com/sidneys/ffmpeg-progressbar-cli/issues/16. It appears that the on('data') was being called multiple times before the SIGKILL message was delivered.